### PR TITLE
Prebundle react

### DIFF
--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -38,9 +38,6 @@
     "queue": "^6.0.1",
     "scheduler": "^0.17.0"
   },
-  "peerDependencies": {
-    "react": "^16.8.6 || ^17.0.0 || ^18.0.0"
-  },
   "lint-staged": {
     "*.js": [
       "yarn run lint",

--- a/packages/renderer/rollup.config.js
+++ b/packages/renderer/rollup.config.js
@@ -39,7 +39,6 @@ const getExternal = ({ browser }) => [
   'react/jsx-runtime',
   ...(browser ? [] : ['fs', 'path', 'url']),
   ...Object.keys(pkg.dependencies).filter(name => name !== 'react-reconciler'),
-  ...Object.keys(pkg.peerDependencies),
 ];
 
 const getPlugins = ({ browser, minify = false }) => [


### PR DESCRIPTION
Workaround for https://github.com/diegomura/react-pdf/issues/2350 by prebundling react into `@react-pdf/renderer`.
Published to npm [`@joshuajaco/react-pdf-renderer-bundled`](https://www.npmjs.com/package/@joshuajaco/react-pdf-renderer-bundled).
This PR is not intended to be merged into upstream.
